### PR TITLE
Enable 3rd party location providers support

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -56,7 +56,7 @@
          be picked. Anyone who wants to disable the overlay mechanism can set it
          to false.
     -->
-    <bool name="config_enableNetworkLocationOverlay">false</bool>
+    <bool name="config_enableNetworkLocationOverlay">true</bool>
 
     <!-- Is the device capable of hot swapping an ICC Card -->
     <bool name="config_hotswapCapable">true</bool>


### PR DESCRIPTION
Because of this string it was impossible to activate MicroG network location providers. 